### PR TITLE
[POC][22] Add Liveman Dockerfile

### DIFF
--- a/Dockerfile-liveman
+++ b/Dockerfile-liveman
@@ -1,0 +1,13 @@
+FROM livebook/livebook:0.2.0
+
+ENV LIVEBOOK_DEFAULT_RUNTIME=mix:/data/lib/liveman_api
+
+WORKDIR /data
+
+RUN mkdir notebook
+COPY ./liveman_api ./lib/liveman_api
+
+# docker build -f Dockerfile-liveman -t liveman ./
+# docker run -p 8080:8080 -e LIVEBOOK_PASSWORD=livemanisawesome -v $(pwd)/notebook:/data/notebook liveman
+
+CMD [ "/app/bin/livebook", "start" ]


### PR DESCRIPTION
https://github.com/nimblehq/liveman-demo-api/projects/2#card-64253865

## What happened

- Set up a docker image with Liveman API included
 
## Insight

To test, run

```
# docker build -f Dockerfile-liveman -t liveman ./
# docker run -p 8080:8080 -e LIVEBOOK_PASSWORD=livemanisawesome -v $(pwd)/notebook:/data/notebook liveman
```
 
## Proof Of Work

Livebook should start properly, now there are 2 folders

- `lib` containing `LivemanAPI`
- `notebook` containing API documentation for the project

![Screen Shot 2564-07-09 at 19 17 24](https://user-images.githubusercontent.com/6965195/125076785-88619e00-e0ea-11eb-9bd6-91145140a560.png)



