### PR TITLE
Fix file reading

### DIFF
--- a/lib/liveman/survey/surveys.ex
+++ b/lib/liveman/survey/surveys.ex
@@ -3,7 +3,7 @@ defmodule Liveman.Survey.Surveys do
 
   alias Liveman.Survey.Schemas.Survey
 
-  @json_file "priv/repo/data/surveys.json"
+  @json_file "#{:code.priv_dir(:liveman)}/repo/data/surveys.json"
 
   def list_surveys do
     survey_list_json = fetch_surveys_from_file!()


### PR DESCRIPTION
## What happened

`surveys.json` file can't read on the Heroku staging server after deployment. To fix it we need to use `:code.priv_dir()` Erlang function to get the `priv` folder path for reading the file. It will work in any environment. More more details, check https://mintcore.se/blog/2017/10/reading-files-from-your-priv-directory-with-elixir
 

## Insight

Used `#{:code.priv_dir(:liveman)}` to get the `priv` folder path
 
 
## Proof Of Work
After deploying manually, it is working as expected
![Screen Shot 2021-07-23 at 11 45 36 AM](https://user-images.githubusercontent.com/6076762/126738400-afb4fe9b-ffe9-4e5c-a8ec-90ca7daeaaff.png)

