### PR TITLE
[15] Document the API endpoint GET v1/surveys

### DIFF
--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -11,8 +11,27 @@ base_url = IO.gets("Base URL") |> String.trim()
 ## Users
 
 ### GET /v1/me
+
 Used to fetch the current user's profile details
 
 ```elixir
 LivemanApi.get(base_url, "/v1/me")
+```
+
+## Surveys
+
+### GET /v1/surveys
+
+Used to fetch all the available surveys.
+
+Returns a 200 OK response
+
+```elixir
+LivemanApi.get(base_url, "/v1/surveys")
+```
+
+Supports pagination by passing the page number and page size as params
+
+```elixir
+LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 ```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -26,11 +26,15 @@ Used to fetch all the available surveys.
 
 Returns a 200 OK response
 
+#### 200 OK
+
 ```elixir
 LivemanApi.get(base_url, "/v1/surveys")
 ```
 
 Supports pagination by passing the page number and page size as params
+
+#### 200 OK
 
 ```elixir
 LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})


### PR DESCRIPTION
Closes #15 

## What happened

✅: Created documentation for the endpoint `/v1/surveys`
 
## Insight

The `/v1/surveys` can paginate the records by passing in query params `page` and `page_size`
 
## Proof Of Work

![Screen Shot 2021-07-23 at 6 23 54 PM](https://user-images.githubusercontent.com/34730459/126775207-8be53afb-4d2f-4d55-988e-cf9bb7e47668.png)
