### PR TITLE
[16] Document the API endpoint POST v1/surveys

### DIFF
--- a/liveman_api/lib/liveman_api.ex
+++ b/liveman_api/lib/liveman_api.ex
@@ -5,23 +5,21 @@ defmodule LivemanApi do
 
   @timeout 30_000
 
-  def get(base_url, url, query \\ %{}) do
+  def get(base_url, url, query \\ %{}, headers \\ []) do
     base_url
-    |> client()
+    |> client(headers)
     |> Tesla.get(url, query: Map.to_list(query))
     |> handle_response()
   end
 
-  def post(base_url, url, body \\ %{}) do
+  def post(base_url, url, body \\ %{}, headers \\ []) do
     base_url
-    |> client()
+    |> client(headers)
     |> Tesla.post(url, body)
     |> handle_response()
   end
 
-  defp client(base_url, opts \\ %{}) do
-    headers = opts[:headers] || []
-
+  defp client(base_url, headers) do
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
       Tesla.Middleware.JSON,

--- a/liveman_api/lib/liveman_api.ex
+++ b/liveman_api/lib/liveman_api.ex
@@ -7,23 +7,23 @@ defmodule LivemanApi do
 
   def get(base_url, url, query \\ %{}, headers \\ []) do
     base_url
-    |> client(headers)
-    |> Tesla.get(url, query: Map.to_list(query))
+    |> client()
+    |> Tesla.get(url, query: Map.to_list(query), headers: headers)
     |> handle_response()
   end
 
   def post(base_url, url, body \\ %{}, headers \\ []) do
     base_url
-    |> client(headers)
-    |> Tesla.post(url, body)
+    |> client()
+    |> Tesla.post(url, body, headers: headers)
     |> handle_response()
   end
 
-  defp client(base_url, headers) do
+  defp client(base_url) do
     middleware = [
       {Tesla.Middleware.BaseUrl, base_url},
       Tesla.Middleware.JSON,
-      {Tesla.Middleware.Headers, [{"Content-Type", "application/json"} | headers]},
+      {Tesla.Middleware.Headers, [{"Content-Type", "application/json"}]},
       {Tesla.Middleware.Timeout, [timeout: @timeout]}
     ]
 

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -44,7 +44,7 @@ Supports pagination by passing the page number and page size as params
 LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 ```
 
-### POST /v1/respnoses
+### POST /v1/responses
 
 Used to create an answer to a particular survey
 

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -35,3 +35,81 @@ Supports pagination by passing the page number and page size as params
 ```elixir
 LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 ```
+
+### POST /v1/surveys
+
+Used to create an answer to a particular survey
+
+Requires a valid access_token in the header
+
+Returns a 201 Created response
+
+#### 201 OK
+
+```elixir
+headers = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
+
+body = %{
+  survey_id: "d5de6a8f8f5f1cfe51bc",
+  questions: [
+    %{
+      id: "940d229e4cd87cd1e202",
+      answers: [
+        %{
+          id: "037574cb93d16800eecd"
+        }
+      ]
+    }
+  ]
+}
+
+LivemanApi.post(base_url, "/v1/responses", body, headers)
+```
+
+It will return a 422 Unprocessable Entity response if a survey or question is invalid
+
+#### 422 Unprocessable Entity
+
+```elixir
+header = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
+
+body = %{
+  survey_id: "invalid",
+  questions: [
+    %{
+      id: "940d229e4cd87cd1e202",
+      answers: [
+        %{
+          id: "037574cb93d16800eecd"
+        }
+      ]
+    }
+  ]
+}
+
+# Invalid Survey
+LivemanApi.post(base_url, "/v1/responses", body, headers)
+```
+
+#### 422 Unprocessable Entity
+
+```elixir
+header = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
+
+body = %{
+  survey_id: "d5de6a8f8f5f1cfe51bc",
+  questions: [
+    %{
+      id: "invalid",
+      answers: [
+        %{
+          id: "037574cb93d16800eecd"
+        }
+      ]
+    }
+  ]
+}
+
+# Invalid Question
+LivemanApi.post(base_url, "/v1/responses", body, headers)
+```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -14,8 +14,12 @@ base_url = IO.gets("Base URL") |> String.trim()
 
 Used to fetch the current user's profile details
 
+### 200 OK
+
 ```elixir
-LivemanApi.get(base_url, "/v1/me")
+headers = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
+
+LivemanApi.get(base_url, "/v1/me", %{}, headers)
 ```
 
 ## Surveys
@@ -36,7 +40,7 @@ Supports pagination by passing the page number and page size as params
 LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 ```
 
-### POST /v1/surveys
+### POST /v1/respnoses
 
 Used to create an answer to a particular survey
 
@@ -44,7 +48,7 @@ Requires a valid access_token in the header
 
 Returns a 201 Created response
 
-#### 201 OK
+#### 201 OK - Valid Params
 
 ```elixir
 headers = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
@@ -68,7 +72,7 @@ LivemanApi.post(base_url, "/v1/responses", body, headers)
 
 It will return a 422 Unprocessable Entity response if a survey or question is invalid
 
-#### 422 Unprocessable Entity
+#### 422 Unprocessable Entity - Invalid Survey
 
 ```elixir
 header = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
@@ -87,11 +91,10 @@ body = %{
   ]
 }
 
-# Invalid Survey
 LivemanApi.post(base_url, "/v1/responses", body, headers)
 ```
 
-#### 422 Unprocessable Entity
+#### 422 Unprocessable Entity - Invalid Question
 
 ```elixir
 header = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]
@@ -110,6 +113,5 @@ body = %{
   ]
 }
 
-# Invalid Question
 LivemanApi.post(base_url, "/v1/responses", body, headers)
 ```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -11,8 +11,27 @@ base_url = IO.gets("Base URL") |> String.trim()
 ## Users
 
 ### GET /v1/me
+
 Used to fetch the current user's profile details
 
 ```elixir
 LivemanApi.get(base_url, "/v1/me")
+```
+
+## Surveys
+
+### GET /v1/surveys
+
+Used to fetch all the available surveys.
+
+Returns a 200 OK response
+
+```elixir
+LivemanApi.get(base_url, "/v1/surveys")
+```
+
+Supports pagination by passing the page number and page size as params
+
+```elixir
+LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 ```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -32,6 +32,8 @@ Used to fetch all the available surveys.
 
 Returns a 200 OK response
 
+### 200 OK
+
 ```elixir
 LivemanApi.get(base_url, "/v1/surveys")
 ```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -14,6 +14,8 @@ base_url = IO.gets("Base URL") |> String.trim()
 
 Used to fetch the current user's profile details
 
+Requires a valid `access_token` in the header
+
 ### 200 OK
 
 ```elixir
@@ -44,11 +46,11 @@ LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 
 Used to create an answer to a particular survey
 
-Requires a valid access_token in the header
+Requires a valid `access_token` in the header
 
 Returns a 201 Created response
 
-#### 201 OK - Valid Params
+#### 201 Created - Valid Params
 
 ```elixir
 headers = [access_token: "77564df8-7823-45b2-b9ef-38dac927ddfd"]


### PR DESCRIPTION
Closes #16 

## What happened

✅: Add POST `/v1/responses`
✅: Modified API Client to accept headers
 
## Insight

We modified the request methods to accept optional headers to help with authentication.
In the documentation, we can pass the access token so that we can make requests to routes that require authentication.
 
## Proof Of Work

![Screen Shot 2021-07-23 at 6 09 00 PM](https://user-images.githubusercontent.com/34730459/126774105-5fffb8f9-7a34-45e6-a284-f7668ffb08cb.png)

