### PR TITLE
[21] Create/update for the API authentication 

### DIFF
--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -198,7 +198,7 @@ This endpoint will return a 200 OK response after successfully verifying the use
 
 ```elixir
 body = %{
-  "otp": "621951"
+  "otp" => "621951"
 }
 
 LivemanApi.post(base_url, "/v1/users/singup", body)
@@ -210,7 +210,7 @@ A 422 Unprocessable Entity error will be raised given an invalid OTP
 
 ```elixir
 body = %{
-  "otp": ""
+  "otp" => ""
 }
 
 LivemanApi.post(base_url, "/v1/users/singup", body)

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -141,3 +141,77 @@ Supports pagination by passing the page number and page size as params
 ```elixir
 LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 ```
+
+## Registration flow
+
+In order for the user to register, they first will need to enter their email and password.
+Upon submitting their email and password, they will be sent an OTP which they can use to verify their email before using the rest of the application
+
+### POST /users/signup
+
+Used to submit the user's credientials, and if successful, will return a message about the confirmation email.
+
+This endpoint will raise a 422 Unprocessable Entity error if the email is already taken
+
+Returns a 200 OK response
+
+#### 200 OK
+
+```elixir
+body = %{
+  "email" => "johndoe@email.com",
+  "password" => "secret"
+}
+
+LivemanApi.post(base_url, "/v1/users/singup", body)
+```
+
+#### 422 Unprocessable Entity - Invalid Email and Password
+
+```elixir
+body = %{
+  "email" => "johndoe",
+  "password" => "qwe"
+}
+
+LivemanApi.post(base_url, "/v1/users/singup", body)
+```
+
+#### 422 Unprocessable Entity - Black Email and Password
+
+```elixir
+body = %{
+  "email" => "",
+  "password" => ""
+}
+
+LivemanApi.post(base_url, "/v1/users/singup", body)
+```
+
+After user registration they have to submit the OTP they received to the verification endpoint
+
+### POST /users/verify
+
+This endpoint will return a 200 OK response after successfully verifying the user
+
+#### 200 OK
+
+```elixir
+body = %{
+  "otp": "621951"
+}
+
+LivemanApi.post(base_url, "/v1/users/singup", body)
+```
+
+A 422 Unprocessable Entity error will be raised given an invalid OTP
+
+#### 422 Unprocessable Entity - Blank OTP
+
+```elixir
+body = %{
+  "otp": ""
+}
+
+LivemanApi.post(base_url, "/v1/users/singup", body)
+```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -163,7 +163,7 @@ body = %{
   "password" => "secret"
 }
 
-LivemanApi.post(base_url, "/v1/users/singup", body)
+LivemanApi.post(base_url, "/v1/users/signup", body)
 ```
 
 #### 422 Unprocessable Entity - Invalid Email and Password
@@ -174,7 +174,7 @@ body = %{
   "password" => "qwe"
 }
 
-LivemanApi.post(base_url, "/v1/users/singup", body)
+LivemanApi.post(base_url, "/v1/users/signup", body)
 ```
 
 #### 422 Unprocessable Entity - Black Email and Password
@@ -185,7 +185,7 @@ body = %{
   "password" => ""
 }
 
-LivemanApi.post(base_url, "/v1/users/singup", body)
+LivemanApi.post(base_url, "/v1/users/signup", body)
 ```
 
 After user registration they will need to submit the OTP they received to the verification endpoint.
@@ -201,7 +201,7 @@ body = %{
   "otp" => "621951"
 }
 
-LivemanApi.post(base_url, "/v1/users/singup", body)
+LivemanApi.post(base_url, "/v1/users/verify", body)
 ```
 
 A 422 Unprocessable Entity error will be raised given an invalid OTP
@@ -213,5 +213,5 @@ body = %{
   "otp" => ""
 }
 
-LivemanApi.post(base_url, "/v1/users/singup", body)
+LivemanApi.post(base_url, "/v1/users/verify", body)
 ```

--- a/notebook/API.livemd
+++ b/notebook/API.livemd
@@ -144,14 +144,14 @@ LivemanApi.get(base_url, "/v1/surveys", %{page: 2, page_size: 8})
 
 ## Registration flow
 
-In order for the user to register, they first will need to enter their email and password.
-Upon submitting their email and password, they will be sent an OTP which they can use to verify their email before using the rest of the application
+For a user to register, they first will need to submit their email and password.
+Upon submitting their email and password, an OTP will be sent to their email which they can use to verify their account before using the rest of the application
 
 ### POST /users/signup
 
-Used to submit the user's credientials, and if successful, will return a message about the confirmation email.
+Used to submit the user's credientials, and if successful, will return a message about the confirmation email being sent.
 
-This endpoint will raise a 422 Unprocessable Entity error if the email is already taken
+This endpoint will raise a 422 Unprocessable Entity error if their email is already taken.
 
 Returns a 200 OK response
 
@@ -188,11 +188,11 @@ body = %{
 LivemanApi.post(base_url, "/v1/users/singup", body)
 ```
 
-After user registration they have to submit the OTP they received to the verification endpoint
+After user registration they will need to submit the OTP they received to the verification endpoint.
 
 ### POST /users/verify
 
-This endpoint will return a 200 OK response after successfully verifying the user
+This endpoint will return a 200 OK response after successfully verifying the user.
 
 #### 200 OK
 


### PR DESCRIPTION
Issue

## What happened

✅: Add documentation for `/user/signup` endpoint
✅: Add documentation for `/user/verify` endpoint
 
## Insight

The user will need to receive an OTP before registering their account 🛑 
 
## Proof Of Work

![Screen Shot 2021-07-30 at 4 14 02 PM](https://user-images.githubusercontent.com/34730459/127631676-59ec8566-13c4-487d-9e71-89b98e0683ba.png)
![Screen Shot 2021-07-30 at 4 14 07 PM](https://user-images.githubusercontent.com/34730459/127631678-8cf42ece-c626-47e6-ab34-f0baa9407e43.png)

